### PR TITLE
feat: add `rewindable()` factory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
     "autoload": {
         "classmap": [
             "src/RewindableGenerator.php"
-        ]
+        ],
+        "files": ["src/functions.php"]
     },
     "autoload-dev": {
         "psr-4": {

--- a/src/functions.php
+++ b/src/functions.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace BenTools\RewindableGenerator;
+
+use BenTools\RewindableGenerator;
+use Generator;
+
+/**
+ * @template TType
+ *
+ * @param iterable<TType> $iterable
+ *
+ * @return iterable<TType>
+ */
+function rewindable(iterable $iterable): iterable
+{
+    if ($iterable instanceof Generator) {
+        return new RewindableGenerator($iterable);
+    }
+
+    return $iterable;
+}

--- a/tests/rewindableTest.php
+++ b/tests/rewindableTest.php
@@ -1,0 +1,22 @@
+<?php
+
+use BenTools\RewindableGenerator;
+
+it('rewindable() accepts Generator', function () {
+    $generator = function () {
+        yield 'foo';
+        yield 'bar';
+    };
+
+    $rewindable = RewindableGenerator\rewindable($generator());
+    $expected = ['foo', 'bar'];
+    expect(iterator_to_array($rewindable))->toEqual($expected)
+        ->and(iterator_to_array($rewindable))->toEqual($expected);
+});
+
+it('rewindable() accepts other iterables', function () {
+    $expected = ['foo', 'bar'];
+    $rewindable = RewindableGenerator\rewindable($expected);
+    expect($rewindable)->toEqual($expected)
+        ->and($rewindable)->toEqual($expected);
+});


### PR DESCRIPTION
This adds a syntax sugar which allows to pass any iterable into RewindableGenerator and if it's generator make it rewindable. Since other iterables are rewindable by default, they're returned as are.